### PR TITLE
Remove superfluous curly bracket from template.tex

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -143,7 +143,7 @@ Detailed achievements:
   \end{itemize}
 \item Achievement 3
 \item Achievement 4
-\end{itemize}}
+\end{itemize}
 \cventry{year--year}{Job title}{Employer}{City}{}{Description line 1\newline{}Description line 2\newline{}Description line 3}
 \subsection{Miscellaneous}
 \cventry{year--year}{Job title}{Employer}{City}{}{Description}


### PR DESCRIPTION
The additional bracket stopped the example from being rendered on my machine. Removing it made it work. 
Not a LaTeX expert, but I'm sure it was just a typo.